### PR TITLE
fix: test with hard coded mapbox tileset name

### DIFF
--- a/.github/workflows/test-docker-action.yml
+++ b/.github/workflows/test-docker-action.yml
@@ -33,3 +33,4 @@ jobs:
           MAPBOXUSERNAME: ${{ secrets.MAPBOXUSERNAME }}
           MAPBOXTOKEN: ${{ secrets.MAPBOXTOKEN }}
           MAPBOXTILESET: ${{ secrets.MAPBOXTILESET }}
+          MAPBOXTILESETDEV: ${{ secrets.MAPBOXTILESETDEV }}

--- a/.github/workflows/test-docker-action.yml
+++ b/.github/workflows/test-docker-action.yml
@@ -33,3 +33,4 @@ jobs:
           MAPBOXUSERNAME: ${{ secrets.MAPBOXUSERNAME }}
           MAPBOXTOKEN: ${{ secrets.MAPBOXTOKEN }}
           MAPBOXTILESET: ${{ secrets.MAPBOXTILESET }}
+          MAPBOXLAYERNAME: ${{ secrets.MAPBOXLAYERNAME }}

--- a/.github/workflows/test-docker-action.yml
+++ b/.github/workflows/test-docker-action.yml
@@ -33,4 +33,3 @@ jobs:
           MAPBOXUSERNAME: ${{ secrets.MAPBOXUSERNAME }}
           MAPBOXTOKEN: ${{ secrets.MAPBOXTOKEN }}
           MAPBOXTILESET: ${{ secrets.MAPBOXTILESET }}
-          MAPBOXTILESETDEV: ${{ secrets.MAPBOXTILESETDEV }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ env:
   MAPBOXUSERNAME: "123"
   MAPBOXTOKEN: "456"
   MAPBOXTILESET: "xyz"
+  MAPBOXLAYERNAME: "abc"
   LOGGING: INFO
   DATABASE_URL: postgresql://fangorn:ent@localhost:5432/trees?schema=public
 

--- a/action.yml
+++ b/action.yml
@@ -56,5 +56,6 @@ runs:
     S3_BUCKET: ${{ inputs.S3_BUCKET }}
     MAPBOXUSERNAME: ${{ inputs.MAPBOXUSERNAME }}
     MAPBOXTOKEN: ${{ inputs.MAPBOXTOKEN }}
+    MAPBOXTILESET: ${{ inputs.MAPBOXTILESET }}
     LOGGING: ${{ inputs.LOGGING }}
     DATABASE_URL: ${{ inputs.DATABASE_URL }}

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,9 @@ inputs:
   MAPBOXTILESET:
     description: ""
     required: true
+  MAPBOXLAYERNAME:
+    description: "The layer within the tileset that holds the trees data"
+    required: true
   LOGGING:
     description: ""
     required: true
@@ -57,5 +60,6 @@ runs:
     MAPBOXUSERNAME: ${{ inputs.MAPBOXUSERNAME }}
     MAPBOXTOKEN: ${{ inputs.MAPBOXTOKEN }}
     MAPBOXTILESET: ${{ inputs.MAPBOXTILESET }}
+    MAPBOXLAYERNAME: ${{ inputs.MAPBOXLAYERNAME }}
     LOGGING: ${{ inputs.LOGGING }}
     DATABASE_URL: ${{ inputs.DATABASE_URL }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       MAPBOXUSERNAME: "123"
       MAPBOXTOKEN: "456"
       MAPBOXTILESET: "xyz"
+      MAPBOXLAYERNAME: "abc"
 
       OUTPUT: "True"
       LOGGING: INFO

--- a/harvester/harvester.py
+++ b/harvester/harvester.py
@@ -403,7 +403,7 @@ if len(filelist) > 0:
             url = "https://api.mapbox.com/uploads/v1/{}?access_token={}".format(
                 os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTOKEN"))
             payload = '{{"url":"http://{}.s3.amazonaws.com/{}","tileset":"{}.{}"}}'.format(
-                s3_credentials["bucket"], s3_credentials["key"], os.getenv("MAPBOXUSERNAME"), "gdktest")
+                s3_credentials["bucket"], s3_credentials["key"], os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTILESET"))
             headers = {'content-type': 'application/json',
                        'Accept-Charset': 'UTF-8', 'Cache-Control': 'no-cache'}
             response = requests.post(url, data=payload, headers=headers)

--- a/harvester/harvester.py
+++ b/harvester/harvester.py
@@ -402,13 +402,11 @@ if len(filelist) > 0:
 
             url = "https://api.mapbox.com/uploads/v1/{}?access_token={}".format(
                 os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTOKEN"))
-            payload = '{{"url":"http://{}.s3.amazonaws.com/{}","tileset":"{}.{}"}}'.format(
-                s3_credentials["bucket"], s3_credentials["key"], os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTILESET"))
+            payload = '{{"url":"http://{}.s3.amazonaws.com/{}","tileset":"{}.{}","name":"GDK Dev Trees"}}'.format(
+                s3_credentials["bucket"], s3_credentials["key"], os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTILESETDEV"))
             headers = {'content-type': 'application/json',
                        'Accept-Charset': 'UTF-8', 'Cache-Control': 'no-cache'}
             response = requests.post(url, data=payload, headers=headers)
-            logging.info(os.getenv("MAPBOXTILESET"))
-            logging.info(payload)
             # wohooo!
             logging.info("✅ Map updated to timespan: {} to {}".format(
                 startdate, enddate))

--- a/harvester/harvester.py
+++ b/harvester/harvester.py
@@ -403,7 +403,7 @@ if len(filelist) > 0:
             url = "https://api.mapbox.com/uploads/v1/{}?access_token={}".format(
                 os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTOKEN"))
             payload = '{{"url":"http://{}.s3.amazonaws.com/{}","tileset":"{}.{}"}}'.format(
-                s3_credentials["bucket"], s3_credentials["key"], os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTILESET"))
+                s3_credentials["bucket"], s3_credentials["key"], os.getenv("MAPBOXUSERNAME"), "gdktest")
             headers = {'content-type': 'application/json',
                        'Accept-Charset': 'UTF-8', 'Cache-Control': 'no-cache'}
             response = requests.post(url, data=payload, headers=headers)

--- a/harvester/harvester.py
+++ b/harvester/harvester.py
@@ -402,8 +402,8 @@ if len(filelist) > 0:
 
             url = "https://api.mapbox.com/uploads/v1/{}?access_token={}".format(
                 os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTOKEN"))
-            payload = '{{"url":"http://{}.s3.amazonaws.com/{}","tileset":"{}.{}","name":"GDK Dev Trees"}}'.format(
-                s3_credentials["bucket"], s3_credentials["key"], os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTILESET"))
+            payload = '{{"url":"http://{}.s3.amazonaws.com/{}","tileset":"{}.{}","name":"{}"}}'.format(
+                s3_credentials["bucket"], s3_credentials["key"], os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTILESET"), os.getenv("MAPBOXLAYERNAME"))
             headers = {'content-type': 'application/json',
                        'Accept-Charset': 'UTF-8', 'Cache-Control': 'no-cache'}
             response = requests.post(url, data=payload, headers=headers)

--- a/harvester/harvester.py
+++ b/harvester/harvester.py
@@ -407,6 +407,8 @@ if len(filelist) > 0:
             headers = {'content-type': 'application/json',
                        'Accept-Charset': 'UTF-8', 'Cache-Control': 'no-cache'}
             response = requests.post(url, data=payload, headers=headers)
+            logging.info(os.getenv("MAPBOXTILESET"))
+            logging.info(payload)
             # wohooo!
             logging.info("✅ Map updated to timespan: {} to {}".format(
                 startdate, enddate))

--- a/harvester/harvester.py
+++ b/harvester/harvester.py
@@ -403,7 +403,7 @@ if len(filelist) > 0:
             url = "https://api.mapbox.com/uploads/v1/{}?access_token={}".format(
                 os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTOKEN"))
             payload = '{{"url":"http://{}.s3.amazonaws.com/{}","tileset":"{}.{}","name":"GDK Dev Trees"}}'.format(
-                s3_credentials["bucket"], s3_credentials["key"], os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTILESETDEV"))
+                s3_credentials["bucket"], s3_credentials["key"], os.getenv("MAPBOXUSERNAME"), os.getenv("MAPBOXTILESET"))
             headers = {'content-type': 'application/json',
                        'Accept-Charset': 'UTF-8', 'Cache-Control': 'no-cache'}
             response = requests.post(url, data=payload, headers=headers)


### PR DESCRIPTION
This PR
- adds the MAPBOXTILESET env var to the action.yml. This is necessary to ensure that the `harvester.py` can use that env var. Previously this was not the vase, that's why out MAPBOXTILESET was always `None`
- adds an understandable name to the tileset -> easier in Mapbox UI to distinguish the tilesets