### PR TITLE
Handle missing tree age when creating CSVs

### DIFF
--- a/harvester/harvester.py
+++ b/harvester/harvester.py
@@ -340,7 +340,9 @@ if len(filelist) > 0:
         for tree in trees:
             newLine = "\n"
             newLine += "{},{},{},{}".format(tree[0], tree[1], tree[2], tree[3])
-            if tree[4] is not None:
+            if tree[4] is None:
+                newLine += ","
+            else:
                 newLine += ",{}".format(int(tree[4]))
             singleCSV += newLine
             trees_csv += newLine


### PR DESCRIPTION
Trees without a planted date (i.e. age) won't be uploaded to mapbox properly.
The CSV files which get generated during a harvest run don't have an age cell for these cases. I guess this leads to them not being imported by the Mapbox Uploads API.

This PR makes sure that there is an empty cell in case a tree doesn't have age data.