### PR TITLE
Update test-harvest.yml

### DIFF
--- a/.github/workflows/test-harvest.yml
+++ b/.github/workflows/test-harvest.yml
@@ -79,7 +79,7 @@ jobs:
           node-version: 18
       - run: npm ci
       - id: semantic-release
-        uses: cycjimmy/semantic-release-action@v2
+        uses: cycjimmy/semantic-release-action@v3
         with:
           semantic_version: 18
         env:


### PR DESCRIPTION
We use a semantic release action version that will stop working soon see https://github.blog/changelog/2022-***0-***-github-actions-deprecating-save-state-and-set-output-commands/