### PR TITLE
Make input geometry configurable

### DIFF
--- a/.github/workflows/test-harvest.yml
+++ b/.github/workflows/test-harvest.yml
@@ -12,6 +12,8 @@ on:
   workflow_dispatch:
 
 env:
+  INPUT_SHAPEFILE: ./assets/Berlin.shp
+  INPUT_SHAPEFILE_BUFFER: 2000
   PG_SERVER: localhost
   PG_PORT: "54322"
   PG_USER: postgres

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 ![](https://img.shields.io/badge/Built%20with%20%E2%9D%A4%EF%B8%8F-at%20Technologiestiftung%20Berlin-blue)
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 # giessdenkiez-de-dwd-harvester
@@ -43,13 +46,17 @@ For mac we can use `brew install gdal`.
 
 The current python binding of gdal is fixed to GDAL==2.4.2. If you get another gdal (`ogrinfo --version`), make sure to upgrade to your version: `pip install GDAL==VERSION_FROM_PREVIOUS_COMMAND`
 
+### Add a geometry (shapefile) for your region
+
+In order to run, this project needs a shapefile for the region you would like to cover. The default region is the City of Berlin, for which a shapefile is included in the repository. You can add your own shapefile to `harvester/assets/`.
+
 ### Configuration
 
-Copy the `sample.env` file and rename to `.env` then update the parameters, most importantly the database connection parameters.
+Copy the `sample.env` file and rename to `.env` then update the parameters, most importantly the database connection parameters and the path to your shapefile.
 
 ## Running
 
-`harvester/prepare.py` shows how the assets/buffer.shp was created. If a bigger buffer is needed change `line 10` accordingly and re-run.
+`harvester/prepare.py` shows how the assets/buffer.shp was created. If a bigger buffer is needed, change the `INPUT_SHAPEFILE_BUFFER` parameter accordingly and re-run.
 
 `harvester/harvester.py` is the actual file for harvesting the data. Simply run, no command line parameters, all settings are in `.env`.
 

--- a/harvester/prepare.py
+++ b/harvester/prepare.py
@@ -1,16 +1,26 @@
 # building a buffer shape for filtering the weather data
+import os
 import geopandas
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
+from dotenv import load_dotenv
 
-berlin = geopandas.read_file("./assets/Berlin.shp")
-berlin = berlin.to_crs("epsg:3857")
-berlin_boundary = geopandas.GeoDataFrame(geopandas.GeoSeries(cascaded_union(berlin['geometry'])))
-berlin_boundary = berlin_boundary.rename(columns={0:'geometry'}).set_geometry('geometry')
+INPUT_PATH_DEFAULT = "./assets/Berlin.shp"
+INPUT_BUFFER_DEFAULT = 2000
 
-berlin_buffer = berlin_boundary.buffer(2000)
-berlin_buffer = berlin_buffer.simplify(1000)
+load_dotenv()
 
-berlin_buffer = geopandas.GeoDataFrame(berlin_buffer)
-berlin_buffer = berlin_buffer.rename(columns={0:'geometry'}).set_geometry('geometry')
-berlin_buffer.crs = "epsg:3857"
-berlin_buffer.to_file("./assets/buffer.shp")
+input_path = os.getenv("INPUT_SHAPEFILE", INPUT_PATH_DEFAULT)
+input_buffer = os.getenv("INPUT_SHAPEFILE_BUFFER", INPUT_BUFFER_DEFAULT)
+
+input = geopandas.read_file(input_path)
+input = input.to_crs("epsg:3857")
+input_boundary = geopandas.GeoDataFrame(geopandas.GeoSeries(unary_union(input['geometry'])))
+input_boundary = input_boundary.rename(columns={0:'geometry'}).set_geometry('geometry')
+
+output = input_boundary.buffer(int(input_buffer))
+output = output.simplify(1000)
+
+output = geopandas.GeoDataFrame(output)
+output = output.rename(columns={0:'geometry'}).set_geometry('geometry')
+output.crs = "epsg:3857"
+output.to_file("./assets/buffer.shp")

--- a/harvester/prepare.py
+++ b/harvester/prepare.py
@@ -1,7 +1,7 @@
 # building a buffer shape for filtering the weather data
 import os
 import geopandas
-from shapely.ops import unary_union
+from shapely.ops import cascaded_union
 from dotenv import load_dotenv
 
 INPUT_PATH_DEFAULT = "./assets/Berlin.shp"
@@ -14,7 +14,7 @@ input_buffer = os.getenv("INPUT_SHAPEFILE_BUFFER", INPUT_BUFFER_DEFAULT)
 
 input = geopandas.read_file(input_path)
 input = input.to_crs("epsg:3857")
-input_boundary = geopandas.GeoDataFrame(geopandas.GeoSeries(unary_union(input['geometry'])))
+input_boundary = geopandas.GeoDataFrame(geopandas.GeoSeries(cascaded_union(input['geometry'])))
 input_boundary = input_boundary.rename(columns={0:'geometry'}).set_geometry('geometry')
 
 output = input_boundary.buffer(int(input_buffer))

--- a/harvester/sample.env
+++ b/harvester/sample.env
@@ -1,3 +1,7 @@
+# Path to shapefile for the region you want to cover, distance for creating buffer geometry
+INPUT_SHAPEFILE=./assets/Berlin.shp
+INPUT_SHAPEFILE_BUFFER=2000
+
 # PostgreSQL Server for storing the data
 PG_SERVER=
 PG_PORT=5432


### PR DESCRIPTION
Make it easier to use this project for regions other than Berlin by adding `.env` parameters for configuring the source shapefile for the buffer:

- Path to input shapefile
- Distance to use for creating the buffer geometry

Defaults to previous settings (Berlin shapefile, buffer distance of 2000).