### PR TITLE
Update terraform for S3 bucket to reflect new access control restrictions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,6 +197,7 @@ override.tf.json
 # example: *tfplan*
 terraform/rds/terraform.tfvars
 terraform/ecs-harvester/terraform.tfvars
+terraform/s3-bucket/terraform.tfvars
 terraform/.vscode/settings.json
 # Logs
 logs

--- a/terraform/.tool-versions
+++ b/terraform/.tool-versions
@@ -1,0 +1,1 @@
+terraform 0.15.1

--- a/terraform/.tool-versions
+++ b/terraform/.tool-versions
@@ -1,1 +1,1 @@
-terraform 0.15.1
+terraform 1.4.6

--- a/terraform/s3-bucket/main.tf
+++ b/terraform/s3-bucket/main.tf
@@ -7,13 +7,33 @@ provider "aws" {
 output "s3-bucket-name-radolan" {
   value = "${aws_s3_bucket.radolan.bucket_domain_name}"
 }
+
+resource "aws_s3_bucket_public_access_block" "uploads" {
+  bucket                  = "${var.prefix}-${var.name}-${var.env}"
+  block_public_policy     = false
+  restrict_public_buckets = false
+}
+
 resource "aws_s3_bucket" "radolan" {
   bucket        = "${var.prefix}-${var.name}-${var.env}"
-  acl           = "public-read"
   force_destroy = true
   versioning {
     enabled = false
   }
+
+  policy = jsonencode({
+    "Version" = "2012-10-17"
+    "Id"      = "Policy-public-read-1"
+    "Statement" = [
+      {
+        "Sid"       = "AllowPublicRead"
+        "Effect"    = "Allow"
+        "Principal" = "*"
+        "Action"    = "s3:GetObject"
+        "Resource"  = "arn:aws:s3:::${var.prefix}-${var.name}-${var.env}/*"
+      }
+    ]
+  })
 
   # Should be added for production
   cors_rule {

--- a/terraform/s3-bucket/terraform.tfvars
+++ b/terraform/s3-bucket/terraform.tfvars
@@ -1,4 +1,0 @@
-profile = "tsberlin"
-region = "eu-central-1"
-env = "dev"
-allowed_origins =  [""]

--- a/terraform/s3-bucket/terraform.tfvars.example
+++ b/terraform/s3-bucket/terraform.tfvars.example
@@ -1,0 +1,5 @@
+# rename me to terraform.tfvars
+profile         = "you"
+region          = "eu-central-1"
+env             = "dev"
+allowed_origins = [""]


### PR DESCRIPTION
Fix problems with the provisioning of the S3 bucket, due to a recent change in AWS related to `acl="public-read"`.

**Background:** As of April 2023, creating a new S3 bucket with the Access Control List (ACL) option [is no longer possible](https://aws.amazon.com/about-aws/whats-new/2022/12/amazon-s3-automatically-enable-block-public-access-disable-access-control-lists-buckets-april-2023/). Due to this change by AWS, the S3 provisioning in this repo is broken. 

See also https://github.com/technologiestiftung/giessdenkiez-de-aws-s3-terraform/issues/6 (different repo, same issue)

---

Bonus fixes:
- [Remove hardcoded tfvars config, add example config instead](https://github.com/technologiestiftung/giessdenkiez-de-dwd-harvester/commit/660fb1556966764349cdbf92c403241d5495d499)
- [Add asdf tool-versions config](https://github.com/technologiestiftung/giessdenkiez-de-dwd-harvester/commit/328ba45307fff7843a3c9eb779fa364461dc135b)
