### PR TITLE
fix: make sad tree buffer larger to catch all trees

### DIFF
--- a/harvester/harvester.py
+++ b/harvester/harvester.py
@@ -280,7 +280,7 @@ if len(filelist) > 0:
     with conn.cursor() as cur:
         psycopg2.extras.execute_batch(
             cur,
-            "UPDATE trees SET radolan_days = %s, radolan_sum = %s WHERE trees.radolan_sum IS NULL AND ST_CoveredBy(geom, ST_Buffer(ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326), 0.00005));",
+            "UPDATE trees SET radolan_days = %s, radolan_sum = %s WHERE trees.radolan_sum IS NULL AND ST_CoveredBy(geom, ST_Buffer(ST_SetSRID(ST_GeomFromGeoJSON(%s), 4326), 0.0002));",
             values
         )
         conn.commit()


### PR DESCRIPTION
It seems like not all trees are caught by the `0.00005` degrees buffer around the polygons. This is not a new bug, but was noticed recently. Increasing the buffer (which is only executed for trees "in the gap" between polygons) fixes the bug. There might be cleaner fixes for that but would require a lot of rewriting the harvester (starting from generating the polygons, which are a little bit off). 

![image (2)](https://github.com/technologiestiftung/giessdenkiez-de-dwd-harvester/assets/10830180/8dc8f0f6-2a4f-4a3d-8cbf-60d28005e2cd)
